### PR TITLE
Include mandatory/recommended 3DS 2.0 fields

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,11 +1,11 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Pay and Shop Ltd t/a Global Payments
+Copyright (c) 2019 Global Payments
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the Software), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, andor sell
+to use, copy, modify, merge, publish, distribute, sublicense, and or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
+# Please use our new PHP SDK
+We've moved. We highly recommend you use the Global Payments PHP SDK
+which supports all the features of this SDK and will benefit from all future releases:
+https://github.com/globalpayments/php-sdk
+
+With the latest update (1.1.3) this SDK supports the mandatory and recommended HPP fields for 3D Secure 2. Going forward it will only receive critical security updates, no further feature updates will be released beyond 3D Secure 2.
+
 # Realex Payments HPP PHP SDK
-You can sign up for a free Realex Payments sandbox account at https://developer.realexpayments.com
+You can sign up for a Global Payments (formerly Realex Payments) account at https://developer.globalpay.com
 
 ## Requirements ##
 - PHP >= 5.3.9
+- For security and support we highly recommend you use PHP 7
 - Composer (https://getcomposer.org/)
 
 ## Instructions ##
@@ -12,7 +20,7 @@ You can sign up for a free Realex Payments sandbox account at https://developer.
     ```
     {
         "require": {
-            "realexpayments/rxp-hpp-php": "1.1.2"
+            "realexpayments/rxp-hpp-php": "1.1.3"
         }    
     }
     ```
@@ -32,71 +40,80 @@ You can sign up for a free Realex Payments sandbox account at https://developer.
 3. Add a reference to the autoloader class anywhere you need to use the sdk
 
     ```php
-    require_once ( 'vendor/autoload.php' );
+    require_once ('vendor/autoload.php');
     ```
 
 4. Use the sdk <br/>
 
     ```php
-	$hppRequest = ( new HppRequest() )
-		->addMerchantId( "myMerchantId" )
-		->addAccount( "mySubAccount" )
-        ....
+    $hppRequest = new HppRequest(); 
+    $hppRequest->addMerchantId("MerchantId");
+    $hppRequest->addAccount("internet");
+    ....
 	```
 
-##SDK Example##
+## Usage
 
-### Creating Request JSON for Realex JS SDK
+### Creating HPP Request JSON for Realex Payments JS Library
 
 ```php
-require_once ( 'vendor/autoload.php' );
+<?php
+require_once ('vendor/autoload.php');
 
 use com\realexpayments\hpp\sdk\domain\HppRequest;
 use com\realexpayments\hpp\sdk\RealexHpp;
+use com\realexpayments\hpp\sdk\RealexValidationException;
+use com\realexpayments\hpp\sdk\RealexException;
 
-$hppRequest = ( new HppRequest() )
-	->addMerchantId( "myMerchantId" )
-	->addAccount( "mySubAccount" )
-	->addAmount( "1001" )
-	->addCurrency( "EUR" )
-	->addAutoSettleFlag( "1" );
+$hppRequest = new HppRequest(); 
+$hppRequest->addMerchantId("MerchantId");
+$hppRequest->addAccount("internet");
+$hppRequest->addAmount("1001");
+$hppRequest->addCurrency("EUR");
+$hppRequest->addAutoSettleFlag(TRUE);
+$hppRequest->addHppVersion("2");
+// 3D Secure 2 Mandatory and Recommended Fields
+$hppRequest->addCustomerEmailAddress("james.mason@example.com");
+$hppRequest->addCustomerMobilePhoneNumber("44|07123456789");
+$hppRequest->addBillingAddressLine1("Flat 123");
+$hppRequest->addBillingAddressLine2("House 456");
+$hppRequest->addBillingAddressLine3("Unit 4");
+$hppRequest->addBillingCity("Halifax");
+$hppRequest->addBillingPostalCode("W5 9HR");
+$hppRequest->addBillingCountryCode("826");
+$hppRequest->addShippingAddressLine1("Apartment 825");
+$hppRequest->addShippingAddressLine2("Complex 741");
+$hppRequest->addShippingAddressLine3("House 963");
+$hppRequest->addShippingCity("Chicago");
+$hppRequest->addShippingState("IL");
+$hppRequest->addShippingPostalCode("50001");
+$hppRequest->addShippingCountryCode("840");
 
-$supplementaryData = array();
-$supplementaryData['key1'] = 'value1';
-$supplementaryData['key2'] = 'value2';
+$realexHpp = new RealexHpp("Shared Secret");
 
-$hppRequest->addSupplementaryData( $supplementaryData );	
-	
-$realexHpp = new RealexHpp( "mySecret" );
-$requestJson = $realexHpp->requestToJson( $hppRequest );
+try {
+    $requestJson = $realexHpp->requestToJson($hppRequest, false);
+    // TODO: pass the HPP request JSON to the JavaScript, iOS or Android Library
+}
+catch (RealexValidationException $e) {
+    // TODO: Add your error handling here
+}
+catch (RealexException $e) {
+    // TODO: Add your error handling here
+}
 ```
 
-### Consuming Response JSON from Realex Payments JS SDK
+### Consuming Response JSON from Realex Payments JS Library
 
 ```php
-require_once ( 'vendor/autoload.php' );
+<?php
+require_once ('vendor/autoload.php');
 
 use com\realexpayments\hpp\sdk\domain\HppResponse;
 use com\realexpayments\hpp\sdk\RealexHpp;
 
-$realexHpp = new RealexHpp( "mySecret" );
-$hppResponse = $realexHpp->responseFromJson( responseJson );
-```
-### HPP Select Stored Card
-```php
-$hppRequest = new HppRequest();
-$hppRequest
-	        ->addAmount("1001")
-	        ->addCurrency("EUR")
-	        ->addAccount("accountId")
-	        ->addMerchantId("merchantId")
-	        ->addAutoSettleFlag("1")
-		    ->addHppSelectStoredCard("payerRef")
-		    ->addPayerExists("1")
-		    ->addOfferSaveCard("1");
-			
-$realexHpp = new RealexHpp("secret");
-$requestJson = $realexHpp->requestToJson($hppRequest);
+$realexHpp = new RealexHpp("mySecret");
+$hppResponse = $realexHpp->responseFromJson(responseJson);
 ```
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,13 @@
   "autoload": {
     "psr-4": {
       "com\\realexpayments\\hpp\\sdk\\": [
+        "src/main/php/com-realexpayments-hpp-sdk"
+      ]
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "com\\realexpayments\\hpp\\sdk\\": [
         "src/main/php/com-realexpayments-hpp-sdk",
         "test/main/php/com-realexpayments-hpp-sdk"
       ]

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     "doctrine/annotations":"1.2.*",
     "doctrine/cache":"1.4.*"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7"
+  },
   "autoload": {
     "psr-4": {
       "com\\realexpayments\\hpp\\sdk\\": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">test</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/main/php/com-realexpayments-hpp-sdk/domain/HppRequest.php
+++ b/src/main/php/com-realexpayments-hpp-sdk/domain/HppRequest.php
@@ -355,8 +355,143 @@ class HppRequest {
 	 * @Assert\Length(min = 0, max = 255, maxMessage = ValidationMessages::hppRequest_postResponse_size, charset="ISO-8859-1")
 	 * @Assert\Regex(pattern="/^[\s \x{0020}-\x{003B} \x{003D} \x{003F}-\x{007E} \x{00A1}-\x{00FF}\x{20AC}\x{201A}\x{0192}\x{201E}\x{2026}\x{2020}\x{2021}\x{02C6}\x{2030}\x{0160}\x{2039}\x{0152}\x{017D}\x{2018}\x{2019}\x{201C}\x{201D}\x{2022}\x{2013}\x{2014}\x{02DC}\x{2122}\x{0161}\x{203A}\x{0153}\x{017E}\x{0178}]*$/iu", message=ValidationMessages::hppRequest_postResponse_pattern )
 	 */
-
 	private $postResponse;
+
+	/**
+	 * @var string Customer's email address, including the full domain name. The field must be submitted in the form
+	 * `name@host.domain` (for example, `james.mason@example.com`).
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $customerEmailAddress;
+
+	/**
+	 * @var string The mobile phone number provided by the Cardholder. Should be in format `CountryCallingCode|Number`
+	 * (for example, `1|123456789`).
+	 * 
+	 * European merchants: mandatory for SCA if captured by your application or website. Global Payments recommend you send at least one phone number (Mobile, Home or Work).
+	 */
+	private $customerMobilePhoneNumber;
+
+	/**
+	 * @var string First line of the customer's billing address.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingAddressLine1;
+
+	/**
+	 * @var string Second line of the customer's billing address. Can be submitted as blank if not relevant for the particular customer.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingAddressLine2;
+
+	/**
+	 * @var string Third line of the customer's billing address. Can be submitted as blank if not relevant for the particular customer.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingAddressLine3;
+
+	/**
+	 * @var string The city of the customer's billing address.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingCity;
+
+	/**
+	 * @var string The state of the customer's billing address. Should be the country subdivision code defined in ISO 3166-2.
+	 * 
+	 * European merchants: if state applicable for the billing address country, required for SCA.
+	 */ 
+	private $billingState;
+
+	/**
+	 * @var string ZIP or other postal code customer's billing address.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingPostalCode;
+
+	/**
+	 * @var string The country of the customer's billing address. ISO 3166-1 numeric three-digit country code.
+	 * 
+	 * European merchants: mandatory for SCA.
+	 */
+	private $billingCountryCode;
+
+	/**
+	 * @var string First line of the customer's shipping address.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingAddressLine1;
+
+	/**
+	 * @var string Second line of the customer's shipping address.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingAddressLine2;
+
+	/**
+	 * @var string Third line of the customer's shipping address.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingAddressLine3;
+
+	/**
+	 * @var string The city of the customer's shipping address.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingCity;
+
+	/**
+	 * @var string The state of the customer's shipping address. Should be the country subdivision code defined in ISO 3166-2.
+	 * 
+	 * European merchants: if applicable for the shipping address country, optional for SCA.
+	 */
+	private $shippingState;
+
+	/**
+	 * @var string ZIP or other postal code customer's shipping address.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingPostalCode;
+
+	/**
+	 * @var string The country of the customer's shipping address. ISO 3166-1 numeric three-digit country code.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingCountryCode;
+
+	/**
+	 * @var boolean Indicates whether the shipping address matches the billing address. Allowed values:
+	 * 
+	 * `TRUE` - Shipping Address matches Billing Address
+	 * `FALSE` - Shipping Address does not match Billing Address
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $shippingAddressMatchIndicator;
+
+	/**
+	 * @var string Indicates whether a challenge is requested for this transaction. The Issuer may override whatever preference is specified in this field. Allowed values:
+	 * 
+	 * `NO_PREFERENCE` - No preference as to whether the customer is challenged
+	 * `NO_CHALLENGE_REQUESTED` - Preference is for the customer not be challenged.
+	 * `CHALLENGE_PREFERRED` - Preference is for the customer to be challenged.
+	 * `CHALLENGE_MANDATED` - A challenge is required for the transaction to be authorised due to local/regional mandates or other variables.
+	 * 
+	 * European merchants: optional for SCA.
+	 */
+	private $challengeRequestIndicator;
 	
 	/**
 	 * Getter for merchantId
@@ -873,7 +1008,6 @@ class HppRequest {
 	public function setPayerExists( $payerExists ) {
 		$this->payerExists = $payerExists;
 	}
-
 
 	/**
 	 * Helper method for adding a merchantId
@@ -1427,6 +1561,529 @@ class HppRequest {
 	}
 
 	/**
+	 * Getter for customerEmailAddress
+	 *
+	 * @return string
+	 */
+	public function getCustomerEmailAddress() {
+		return $this->customerEmailAddress;
+	}
+
+	/**
+	 * Setter for customerEmailAddress
+	 * 
+	 * @param string $customerEmailAddress
+	 */
+	public function setCustomerEmailAddress( $customerEmailAddress ) {
+		$this->customerEmailAddress = $customerEmailAddress;
+	}
+
+	/**
+	 * Getter for customerMobilePhoneNumber
+	 *
+	 * @return string
+	 */
+	public function getCustomerMobilePhoneNumber() {
+		return $this->customerMobilePhoneNumber;
+	}
+
+	/**
+	 * Setter for customerMobilePhoneNumber
+	 * 
+	 * @param string $customerMobilePhoneNumber
+	 */
+	public function setCustomerMobilePhoneNumber( $customerMobilePhoneNumber ) {
+		$this->customerMobilePhoneNumber = $customerMobilePhoneNumber;
+	}
+
+	/**
+	 * Getter for billingAddressLine1
+	 *
+	 * @return string
+	 */
+	public function getBillingAddressLine1() {
+		return $this->billingAddressLine1;
+	}
+
+	/**
+	 * Setter for billingAddressLine1
+	 * 
+	 * @param string $billingAddressLine1
+	 */
+	public function setBillingAddressLine1( $billingAddressLine1 ) {
+		$this->billingAddressLine1 = $billingAddressLine1;
+	}
+
+	/**
+	 * Getter for billingAddressLine2
+	 *
+	 * @return string
+	 */
+	public function getBillingAddressLine2() {
+		return $this->billingAddressLine2;
+	}
+
+	/**
+	 * Setter for billingAddressLine2
+	 * 
+	 * @param string $billingAddressLine2
+	 */
+	public function setBillingAddressLine2( $billingAddressLine2 ) {
+		$this->billingAddressLine2 = $billingAddressLine2;
+	}
+
+	/**
+	 * Getter for billingAddressLine3
+	 *
+	 * @return string
+	 */
+	public function getBillingAddressLine3() {
+		return $this->billingAddressLine3;
+	}
+
+	/**
+	 * Setter for billingAddressLine3
+	 * 
+	 * @param string $billingAddressLine3
+	 */
+	public function setBillingAddressLine3( $billingAddressLine3 ) {
+		$this->billingAddressLine3 = $billingAddressLine3;
+	}
+
+	/**
+	 * Getter for billingCity
+	 *
+	 * @return string
+	 */
+	public function getBillingCity() {
+		return $this->billingCity;
+	}
+
+	/**
+	 * Setter for billingCity
+	 * 
+	 * @param string $billingCity
+	 */
+	public function setBillingCity( $billingCity ) {
+		$this->billingCity = $billingCity;
+	}
+
+	/**
+	 * Getter for billingState
+	 *
+	 * @return string
+	 */
+	public function getBillingState() {
+		return $this->billingState;
+	}
+
+	/**
+	 * Setter for billingState
+	 * 
+	 * @param string $billingState
+	 */
+	public function setBillingState( $billingState ) {
+		$this->billingState = $billingState;
+	}
+
+	/**
+	 * Getter for billingPostalCode
+	 *
+	 * @return string
+	 */
+	public function getBillingPostalCode() {
+		return $this->billingPostalCode;
+	}
+
+	/**
+	 * Setter for billingPostalCode
+	 * 
+	 * @param string $billingPostalCode
+	 */
+	public function setBillingPostalCode( $billingPostalCode ) {
+		$this->billingPostalCode = $billingPostalCode;
+	}
+
+	/**
+	 * Getter for billingCountryCode
+	 *
+	 * @return string
+	 */
+	public function getBillingCountryCode() {
+		return $this->billingCountryCode;
+	}
+
+	/**
+	 * Setter for billingCountryCode
+	 * 
+	 * @param string $billingCountryCode
+	 */
+	public function setBillingCountryCode( $billingCountryCode ) {
+		$this->billingCountryCode = $billingCountryCode;
+	}
+
+	/**
+	 * Getter for shippingAddressLine1
+	 *
+	 * @return string
+	 */
+	public function getShippingAddressLine1() {
+		return $this->shippingAddressLine1;
+	}
+
+	/**
+	 * Setter for shippingAddressLine1
+	 * 
+	 * @param string $shippingAddressLine1
+	 */
+	public function setShippingAddressLine1( $shippingAddressLine1 ) {
+		$this->shippingAddressLine1 = $shippingAddressLine1;
+	}
+
+	/**
+	 * Getter for shippingAddressLine2
+	 *
+	 * @return string
+	 */
+	public function getShippingAddressLine2() {
+		return $this->shippingAddressLine2;
+	}
+
+	/**
+	 * Setter for shippingAddressLine2
+	 * 
+	 * @param string $shippingAddressLine2
+	 */
+	public function setShippingAddressLine2( $shippingAddressLine2 ) {
+		$this->shippingAddressLine2 = $shippingAddressLine2;
+	}
+
+	/**
+	 * Getter for shippingAddressLine3
+	 *
+	 * @return string
+	 */
+	public function getShippingAddressLine3() {
+		return $this->shippingAddressLine3;
+	}
+
+	/**
+	 * Setter for shippingAddressLine3
+	 * 
+	 * @param string $shippingAddressLine3
+	 */
+	public function setShippingAddressLine3( $shippingAddressLine3 ) {
+		$this->shippingAddressLine3 = $shippingAddressLine3;
+	}
+
+	/**
+	 * Getter for shippingCity
+	 *
+	 * @return string
+	 */
+	public function getShippingCity() {
+		return $this->shippingCity;
+	}
+
+	/**
+	 * Setter for shippingCity
+	 * 
+	 * @param string $shippingCity
+	 */
+	public function setShippingCity( $shippingCity ) {
+		$this->shippingCity = $shippingCity;
+	}
+
+	/**
+	 * Getter for shippingState
+	 *
+	 * @return string
+	 */
+	public function getShippingState() {
+		return $this->shippingState;
+	}
+
+	/**
+	 * Setter for shippingState
+	 * 
+	 * @param string $shippingState
+	 */
+	public function setShippingState( $shippingState ) {
+		$this->shippingState = $shippingState;
+	}
+
+	/**
+	 * Getter for shippingPostalCode
+	 *
+	 * @return string
+	 */
+	public function getShippingPostalCode() {
+		return $this->shippingPostalCode;
+	}
+
+	/**
+	 * Setter for shippingPostalCode
+	 * 
+	 * @param string $shippingPostalCode
+	 */
+	public function setShippingPostalCode( $shippingPostalCode ) {
+		$this->shippingPostalCode = $shippingPostalCode;
+	}
+
+	/**
+	 * Getter for shippingCountryCode
+	 *
+	 * @return string
+	 */
+	public function getShippingCountryCode() {
+		return $this->shippingCountryCode;
+	}
+
+	/**
+	 * Setter for shippingCountryCode
+	 * 
+	 * @param string $shippingCountryCode
+	 */
+	public function setShippingCountryCode( $shippingCountryCode ) {
+		$this->shippingCountryCode = $shippingCountryCode;
+	}
+
+	/**
+	 * Getter for shippingAddressMatchIndicator
+	 *
+	 * @return boolean
+	 */
+	public function getShippingAddressMatchIndicator() {
+		return $this->shippingAddressMatchIndicator;
+	}
+
+	/**
+	 * Setter for shippingAddressMatchIndicator
+	 * 
+	 * @param boolean $shippingAddressMatchIndicator
+	 */
+	public function setShippingAddressMatchIndicator( $shippingAddressMatchIndicator ) {
+		$this->shippingAddressMatchIndicator = (bool)$shippingAddressMatchIndicator;
+	}
+
+	/**
+	 * Getter for challengeRequestIndicator
+	 *
+	 * @return string
+	 */
+	public function getChallengeRequestIndicator() {
+		return $this->challengeRequestIndicator;
+	}
+
+	/**
+	 * Setter for challengeRequestIndicator
+	 * 
+	 * @param string $challengeRequestIndicator
+	 */
+	public function setChallengeRequestIndicator( $challengeRequestIndicator ) {
+		$this->challengeRequestIndicator = $challengeRequestIndicator;
+	}
+
+	/**
+	 * Helper method for setting customerEmailAddress
+	 * 
+	 * @param string $customerEmailAddress
+	 * @return HppRequest
+	 */
+	public function addCustomerEmailAddress( $customerEmailAddress ) {
+		$this->setCustomerEmailAddress($customerEmailAddress);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting customerMobilePhoneNumber
+	 * 
+	 * @param string $customerMobilePhoneNumber
+	 * @return HppRequest
+	 */
+	public function addCustomerMobilePhoneNumber( $customerMobilePhoneNumber ) {
+		$this->setCustomerMobilePhoneNumber($customerMobilePhoneNumber);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingAddressLine1
+	 * 
+	 * @param string $billingAddressLine1
+	 * @return HppRequest
+	 */
+	public function addBillingAddressLine1( $billingAddressLine1 ) {
+		$this->setBillingAddressLine1($billingAddressLine1);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingAddressLine2
+	 * 
+	 * @param string $billingAddressLine2
+	 * @return HppRequest
+	 */
+	public function addBillingAddressLine2( $billingAddressLine2 ) {
+		$this->setBillingAddressLine2($billingAddressLine2);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingAddressLine3
+	 * 
+	 * @param string $billingAddressLine3
+	 * @return HppRequest
+	 */
+	public function addBillingAddressLine3( $billingAddressLine3 ) {
+		$this->setBillingAddressLine3($billingAddressLine3);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingCity
+	 * 
+	 * @param string $billingCity
+	 * @return HppRequest
+	 */
+	public function addBillingCity( $billingCity ) {
+		$this->setBillingCity($billingCity);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingState
+	 * 
+	 * @param string $billingState
+	 * @return HppRequest
+	 */
+	public function addBillingState( $billingState ) {
+		$this->setBillingState($billingState);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingPostalCode
+	 * 
+	 * @param string $billingPostalCode
+	 * @return HppRequest
+	 */
+	public function addBillingPostalCode( $billingPostalCode ) {
+		$this->setBillingPostalCode($billingPostalCode);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting billingCountryCode
+	 * 
+	 * @param string $billingCountryCode
+	 * @return HppRequest
+	 */
+	public function addBillingCountryCode( $billingCountryCode ) {
+		$this->setBillingCountryCode($billingCountryCode);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingAddressLine1
+	 * 
+	 * @param string $shippingAddressLine1
+	 * @return HppRequest
+	 */
+	public function addShippingAddressLine1( $shippingAddressLine1 ) {
+		$this->setShippingAddressLine1($shippingAddressLine1);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingAddressLine2
+	 * 
+	 * @param string $shippingAddressLine2
+	 * @return HppRequest
+	 */
+	public function addShippingAddressLine2( $shippingAddressLine2 ) {
+		$this->setShippingAddressLine2($shippingAddressLine2);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingAddressLine3
+	 * 
+	 * @param string $shippingAddressLine3
+	 * @return HppRequest
+	 */
+	public function addShippingAddressLine3( $shippingAddressLine3 ) {
+		$this->setShippingAddressLine3($shippingAddressLine3);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingCity
+	 * 
+	 * @param string $shippingCity
+	 * @return HppRequest
+	 */
+	public function addShippingCity( $shippingCity ) {
+		$this->setShippingCity($shippingCity);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingState
+	 * 
+	 * @param string $shippingState
+	 * @return HppRequest
+	 */
+	public function addShippingState( $shippingState ) {
+		$this->setShippingState($shippingState);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingPostalCode
+	 * 
+	 * @param string $shippingPostalCode
+	 * @return HppRequest
+	 */
+	public function addShippingPostalCode( $shippingPostalCode ) {
+		$this->setShippingPostalCode($shippingPostalCode);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingCountryCode
+	 * 
+	 * @param string $shippingCountryCode
+	 * @return HppRequest
+	 */
+	public function addShippingCountryCode( $shippingCountryCode ) {
+		$this->setShippingCountryCode($shippingCountryCode);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting shippingAddressMatchIndicator
+	 * 
+	 * @param boolean $shippingAddressMatchIndicator
+	 * @return HppRequest
+	 */
+	public function addShippingAddressMatchIndicator( $shippingAddressMatchIndicator ) {
+		$this->setShippingAddressMatchIndicator($shippingAddressMatchIndicator);
+		return $this;
+	}
+
+	/**
+	 * Helper method for setting challengeRequestIndicator
+	 * 
+	 * @param string $challengeRequestIndicator
+	 * @return HppRequest
+	 */
+	public function addChallengeRequestIndicator( $challengeRequestIndicator ) {
+		$this->setChallengeRequestIndicator($challengeRequestIndicator);
+		return $this;
+	}
+
+
+	/**
 	 * Generates default values for fields such as hash, timestamp and order ID.
 	 *
 	 * @param String $secret
@@ -1576,6 +2233,24 @@ class HppRequest {
 		$this->hppSelectStoredCard    = base64_encode( $this->hppSelectStoredCard );
 		$this->postResponse   		 = base64_encode( $this->postResponse );
 		$this->postDimensions   	 = base64_encode( $this->postDimensions );
+		$this->customerEmailAddress = base64_encode( $this->customerEmailAddress );
+		$this->customerMobilePhoneNumber = base64_encode( $this->customerMobilePhoneNumber );
+		$this->billingAddressLine1 = base64_encode( $this->billingAddressLine1 );
+		$this->billingAddressLine2 = base64_encode( $this->billingAddressLine2 );
+		$this->billingAddressLine3 = base64_encode( $this->billingAddressLine3 );
+		$this->billingCity = base64_encode( $this->billingCity );
+		$this->billingState = base64_encode( $this->billingState );
+		$this->billingPostalCode = base64_encode( $this->billingPostalCode );
+		$this->billingCountryCode = base64_encode( $this->billingCountryCode );
+		$this->shippingAddressLine1 = base64_encode( $this->shippingAddressLine1 );
+		$this->shippingAddressLine2 = base64_encode( $this->shippingAddressLine2 );
+		$this->shippingAddressLine3 = base64_encode( $this->shippingAddressLine3 );
+		$this->shippingCity = base64_encode( $this->shippingCity );
+		$this->shippingState = base64_encode( $this->shippingState );
+		$this->shippingPostalCode = base64_encode( $this->shippingPostalCode );
+		$this->shippingCountryCode = base64_encode( $this->shippingCountryCode );
+		$this->shippingAddressMatchIndicator = base64_encode( $this->shippingAddressMatchIndicator );
+		$this->challengeRequestIndicator = base64_encode( $this->challengeRequestIndicator );
 
 		if ( is_array( $this->supplementaryData ) ) {
 			foreach ( $this->supplementaryData as $key => $value ) {
@@ -1628,6 +2303,24 @@ class HppRequest {
 		$this->hppSelectStoredCard   	= base64_decode( $this->hppSelectStoredCard );
 		$this->postResponse   		= base64_decode( $this->postResponse );
 		$this->postDimensions   	= base64_decode( $this->postDimensions );
+		$this->customerEmailAddress = base64_decode( $this->customerEmailAddress );
+		$this->customerMobilePhoneNumber = base64_decode( $this->customerMobilePhoneNumber );
+		$this->billingAddressLine1 = base64_decode( $this->billingAddressLine1 );
+		$this->billingAddressLine2 = base64_decode( $this->billingAddressLine2 );
+		$this->billingAddressLine3 = base64_decode( $this->billingAddressLine3 );
+		$this->billingCity = base64_decode( $this->billingCity );
+		$this->billingState = base64_decode( $this->billingState );
+		$this->billingPostalCode = base64_decode( $this->billingPostalCode );
+		$this->billingCountryCode = base64_decode( $this->billingCountryCode );
+		$this->shippingAddressLine1 = base64_decode( $this->shippingAddressLine1 );
+		$this->shippingAddressLine2 = base64_decode( $this->shippingAddressLine2 );
+		$this->shippingAddressLine3 = base64_decode( $this->shippingAddressLine3 );
+		$this->shippingCity = base64_decode( $this->shippingCity );
+		$this->shippingState = base64_decode( $this->shippingState );
+		$this->shippingPostalCode = base64_decode( $this->shippingPostalCode );
+		$this->shippingCountryCode = base64_decode( $this->shippingCountryCode );
+		$this->shippingAddressMatchIndicator = base64_decode( $this->shippingAddressMatchIndicator );
+		$this->challengeRequestIndicator = base64_decode( $this->challengeRequestIndicator );
 
 
 		if ( is_array( $this->supplementaryData ) ) {
@@ -1678,7 +2371,25 @@ class HppRequest {
 	    $this->hppVersion = $this->nullToEmptyString($this->hppVersion);
 	    $this->hppSelectStoredCard = $this->nullToEmptyString($this->hppSelectStoredCard);
 	    $this->postResponse = $this->nullToEmptyString($this->postResponse);
-	    $this->postDimensions = $this->nullToEmptyString($this->postDimensions);
+			$this->postDimensions = $this->nullToEmptyString($this->postDimensions);
+			$this->customerEmailAddress = $this->nullToEmptyString($this->customerEmailAddress);
+			$this->customerMobilePhoneNumber = $this->nullToEmptyString($this->customerMobilePhoneNumber);
+			$this->billingAddressLine1 = $this->nullToEmptyString($this->billingAddressLine1);
+			$this->billingAddressLine2 = $this->nullToEmptyString($this->billingAddressLine2);
+			$this->billingAddressLine3 = $this->nullToEmptyString($this->billingAddressLine3);
+			$this->billingCity = $this->nullToEmptyString($this->billingCity);
+			$this->billingState = $this->nullToEmptyString($this->billingState);
+			$this->billingPostalCode = $this->nullToEmptyString($this->billingPostalCode);
+			$this->billingCountryCode = $this->nullToEmptyString($this->billingCountryCode);
+			$this->shippingAddressLine1 = $this->nullToEmptyString($this->shippingAddressLine1);
+			$this->shippingAddressLine2 = $this->nullToEmptyString($this->shippingAddressLine2);
+			$this->shippingAddressLine3 = $this->nullToEmptyString($this->shippingAddressLine3);
+			$this->shippingCity = $this->nullToEmptyString($this->shippingCity);
+			$this->shippingState = $this->nullToEmptyString($this->shippingState);
+			$this->shippingPostalCode = $this->nullToEmptyString($this->shippingPostalCode);
+			$this->shippingCountryCode = $this->nullToEmptyString($this->shippingCountryCode);
+			$this->shippingAddressMatchIndicator = $this->nullToEmptyString($this->shippingAddressMatchIndicator);
+			$this->challengeRequestIndicator = $this->nullToEmptyString($this->challengeRequestIndicator);
 	    
 	    if (is_array($this->supplementaryData)) {
 	        foreach ($this->supplementaryData as $key => $value) {

--- a/src/main/php/com-realexpayments-hpp-sdk/utils/RequestMapper.php
+++ b/src/main/php/com-realexpayments-hpp-sdk/utils/RequestMapper.php
@@ -40,6 +40,24 @@ class RequestMapper implements iMapper {
 		'HPP_SELECT_STORED_CARD',
 		'HPP_POST_DIMENSIONS',
 		'HPP_POST_RESPONSE',
+		'HPP_CUSTOMER_EMAIL',
+		'HPP_CUSTOMER_PHONENUMBER_MOBILE',
+		'HPP_BILLING_STREET1',
+		'HPP_BILLING_STREET2',
+		'HPP_BILLING_STREET3',
+		'HPP_BILLING_CITY',
+		'HPP_BILLING_STATE',
+		'HPP_BILLING_POSTALCODE',
+		'HPP_BILLING_COUNTRY',
+		'HPP_SHIPPING_STREET1',
+		'HPP_SHIPPING_STREET2',
+		'HPP_SHIPPING_STREET3',
+		'HPP_SHIPPING_CITY',
+		'HPP_SHIPPING_STATE',
+		'HPP_SHIPPING_POSTALCODE',
+		'HPP_SHIPPING_COUNTRY',
+		'HPP_ADDRESS_MATCH_INDICATOR',
+		'HPP_CHALLENGE_REQUEST_INDICATOR',
 	);
 
 	/**
@@ -101,6 +119,78 @@ class RequestMapper implements iMapper {
 		if($hppRequest->getPostResponse() != null)
 			$prop['HPP_POST_RESPONSE'] = $hppRequest->getPostResponse();
 
+		if ($hppRequest->getCustomerEmailAddress() != null) {
+			$prop['HPP_CUSTOMER_EMAIL'] = $hppRequest->getCustomerEmailAddress();
+		}
+
+		if ($hppRequest->getCustomerMobilePhoneNumber() != null) {
+			$prop['HPP_CUSTOMER_PHONENUMBER_MOBILE'] = $hppRequest->getCustomerMobilePhoneNumber();
+		}
+
+		if ($hppRequest->getBillingAddressLine1() != null) {
+			$prop['HPP_BILLING_STREET1'] = $hppRequest->getBillingAddressLine1();
+		}
+
+		if ($hppRequest->getBillingAddressLine2() != null) {
+			$prop['HPP_BILLING_STREET2'] = $hppRequest->getBillingAddressLine2();
+		}
+
+		if ($hppRequest->getBillingAddressLine3() != null) {
+			$prop['HPP_BILLING_STREET3'] = $hppRequest->getBillingAddressLine3();
+		}
+
+		if ($hppRequest->getBillingCity() != null) {
+			$prop['HPP_BILLING_CITY'] = $hppRequest->getBillingCity();
+		}
+
+		if ($hppRequest->getBillingState() != null) {
+			$prop['HPP_BILLING_STATE'] = $hppRequest->getBillingState();
+		}
+
+		if ($hppRequest->getBillingPostalCode() != null) {
+			$prop['HPP_BILLING_POSTALCODE'] = $hppRequest->getBillingPostalCode();
+		}
+
+		if ($hppRequest->getBillingCountryCode() != null) {
+			$prop['HPP_BILLING_COUNTRY'] = $hppRequest->getBillingCountryCode();
+		}
+
+		if ($hppRequest->getShippingAddressLine1() != null) {
+			$prop['HPP_SHIPPING_STREET1'] = $hppRequest->getShippingAddressLine1();
+		}
+
+		if ($hppRequest->getShippingAddressLine2() != null) {
+			$prop['HPP_SHIPPING_STREET2'] = $hppRequest->getShippingAddressLine2();
+		}
+
+		if ($hppRequest->getShippingAddressLine3() != null) {
+			$prop['HPP_SHIPPING_STREET3'] = $hppRequest->getShippingAddressLine3();
+		}
+
+		if ($hppRequest->getShippingCity() != null) {
+			$prop['HPP_SHIPPING_CITY'] = $hppRequest->getShippingCity();
+		}
+
+		if ($hppRequest->getShippingState() != null) {
+			$prop['HPP_SHIPPING_STATE'] = $hppRequest->getShippingState();
+		}
+
+		if ($hppRequest->getShippingPostalCode() != null) {
+			$prop['HPP_SHIPPING_POSTALCODE'] = $hppRequest->getShippingPostalCode();
+		}
+
+		if ($hppRequest->getShippingCountryCode() != null) {
+			$prop['HPP_SHIPPING_COUNTRY'] = $hppRequest->getShippingCountryCode();
+		}
+
+		if ($hppRequest->getShippingAddressMatchIndicator() != null) {
+			$prop['HPP_ADDRESS_MATCH_INDICATOR'] = $hppRequest->getShippingAddressMatchIndicator() ? 'TRUE' : 'FALSE';
+		}
+
+		if ($hppRequest->getChallengeRequestIndicator() != null) {
+			$prop['HPP_CHALLENGE_REQUEST_INDICATOR'] = $hppRequest->getChallengeRequestIndicator();
+		}
+
 		return json_encode( $prop );
 	}
 
@@ -152,6 +242,24 @@ class RequestMapper implements iMapper {
 			$hppRequest->setHppSelectStoredCard( $array['HPP_SELECT_STORED_CARD'] );
 			$hppRequest->setPostDimensions( $array['HPP_POST_DIMENSIONS'] );
 			$hppRequest->setPostResponse( $array['HPP_POST_RESPONSE'] );
+			$hppRequest->setCustomerEmailAddress( $array['HPP_CUSTOMER_EMAIL'] );
+			$hppRequest->setCustomerMobilePhoneNumber( $array['HPP_CUSTOMER_PHONENUMBER_MOBILE'] );
+			$hppRequest->setBillingAddressLine1( $array['HPP_BILLING_STREET1'] );
+			$hppRequest->setBillingAddressLine2( $array['HPP_BILLING_STREET2'] );
+			$hppRequest->setBillingAddressLine3( $array['HPP_BILLING_STREET3'] );
+			$hppRequest->setBillingCity( $array['HPP_BILLING_CITY'] );
+			$hppRequest->setBillingState( $array['HPP_BILLING_STATE'] );
+			$hppRequest->setBillingPostalCode( $array['HPP_BILLING_POSTALCODE'] );
+			$hppRequest->setBillingCountryCode( $array['HPP_BILLING_COUNTRY'] );
+			$hppRequest->setShippingAddressLine1( $array['HPP_SHIPPING_STREET1'] );
+			$hppRequest->setShippingAddressLine2( $array['HPP_SHIPPING_STREET2'] );
+			$hppRequest->setShippingAddressLine3( $array['HPP_SHIPPING_STREET3'] );
+			$hppRequest->setShippingCity( $array['HPP_SHIPPING_CITY'] );
+			$hppRequest->setShippingState( $array['HPP_SHIPPING_STATE'] );
+			$hppRequest->setShippingPostalCode( $array['HPP_SHIPPING_POSTALCODE'] );
+			$hppRequest->setShippingCountryCode( $array['HPP_SHIPPING_COUNTRY'] );
+			$hppRequest->setShippingAddressMatchIndicator( $array['HPP_ADDRESS_MATCH_INDICATOR'] );
+			$hppRequest->setChallengeRequestIndicator( $array['HPP_CHALLENGE_REQUEST_INDICATOR'] );
 
 			$supplementaryData = array();
 

--- a/test/main/php/com-realexpayments-hpp-sdk/SampleJsonData.php
+++ b/test/main/php/com-realexpayments-hpp-sdk/SampleJsonData.php
@@ -31,7 +31,7 @@ class SampleJsonData
     const VALID_HPP_RESPONSE_NO_TSS_ENCODED_JSON_PATH = "/sample-json/hpp-response-no-TSS-encoded.json";
     const VALID_HPP_REQUEST_HPP_VERSION_JSON_PATH = "/sample-json/hpp-request-hpp-version-valid.json";
     const INVALID_HPP_REQUEST_HPP_VERSION_JSON_PATH = "/sample-json/hpp-request-hpp-version-fail.json";
-    const VALID_HPP_REQUEST_HPP_VERSION_JSON_PATH2 = "/sample-json/hpp-request-hpp-version-fail2.json";
+    const VALID_HPP_REQUEST_HPP_VERSION_JSON_PATH2 = "/sample-json/hpp-request-hpp-version2.json";
     const VALID_HPP_REQUEST_HPP_POST_DIMENSIONS_JSON_PATH = "/sample-json/hpp-request-post-dimensions-valid.json";
     const INVALID_SIZE_HPP_REQUEST_HPP_POST_DIMENSIONS_JSON_PATH = "/sample-json/hpp-request-post-dimensions-invalid-size.json";
     const INVALID_PATTERN_HPP_REQUEST_HPP_POST_DIMENSIONS_JSON_PATH = "/sample-json/hpp-request-post-dimensions-invalid-pattern.json";
@@ -422,7 +422,7 @@ class SampleJsonData
         $postDimensions = $hppRequestConverted->getPostDimensions();
 
         $testCase->assertEquals(self::POST_DIMENSIONS, $postDimensions, "Json conversion incorrect ");
-        $testCase->assertEquals(sizeof(self::POST_DIMENSIONS), sizeof($postDimensions), "Json conversion incorrect size");
+        $testCase->assertEquals(strlen(self::POST_DIMENSIONS), strlen($postDimensions), "Json conversion incorrect size");
 
         $hppRequestConverted = $hppRequestConverted->encode(RealexHpp::ENCODING_CHARSET);
         $hppRequestConverted = $hppRequestConverted->decode(RealexHpp::ENCODING_CHARSET);


### PR DESCRIPTION
No tests yet because I wanted to start the review process.

I've included a couple additional changes (most of which allow the existing tests to be ran):

- Removed the test files from being autoloaded when developers leverage the SDK in their implementations
- Included a local version of PHPUnit via Composer since the current test cases are incompatible with recent versions of PHPUnit
- Corrected an issue with an HPP version 2 fixture where the wrong filename was being used
- Corrected an issue where `sizeof` was being used in a test to incorrectly calculate a string's length, causing a type error in PHP 7+